### PR TITLE
(fixes #16): Ensure outbound stanzas are logged

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,11 @@
 XML Debugger Plugin Changelog
 </h1>
 
+<p><b>1.7.4</b> -- (tbd)</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/16'>Issue #16</a>] - Outbound stanzas should be logged.</li>
+</ul>
+
 <p><b>1.7.3</b> -- January 11, 2020</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/7'>Issue #7</a>] - CSRF protection support</li>

--- a/src/java/org/jivesoftware/openfire/plugin/RawPrintFilter.java
+++ b/src/java/org/jivesoftware/openfire/plugin/RawPrintFilter.java
@@ -127,8 +127,8 @@ public class RawPrintFilter extends IoFilterAdapter {
 
     @Override
     public void messageSent(final NextFilter nextFilter, final IoSession session, final WriteRequest writeRequest) throws Exception {
-        if (enabled && writeRequest.getMessage() instanceof IoBuffer) {
-            logSentBuffer(session, (IoBuffer) writeRequest.getMessage());
+        if (enabled && writeRequest.getOriginalMessage() instanceof IoBuffer) {
+            logSentBuffer(session, (IoBuffer) writeRequest.getOriginalMessage());
         }
         // Pass the message to the next filter
         super.messageSent(nextFilter, session, writeRequest);


### PR DESCRIPTION
The original code tried to read a buffer that was already flipped. With this change, the original buffer is used instead.