### PR TITLE
Fix compatibility with Openfire 5.0.0 and later

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,8 +44,10 @@
 XML Debugger Plugin Changelog
 </h1>
 
-<p><b>1.8.1</b> -- (To be determined)</p>
+<p><b>1.9.0</b> -- (To be determined)</p>
 <ul>
+    <li>Requires Openfire 5.0.0 or later.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/34'>Issue #34</a>] - Compatible with Openfire 5.0</li>
 </ul>
 
 <p><b>1.8.0</b> -- September 12, 2024</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,9 +9,8 @@
     <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2024-09-12</date>
-    <minServerVersion>4.8.0</minServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
+    <date>2026-05-13</date>
+    <minServerVersion>5.0.0</minServerVersion>
     <csrfProtectionEnabled>true</csrfProtectionEnabled>
 
    <adminconsole>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.8.0-beta</version>
+        <version>5.0.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>xmldebugger</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <name>XML Debugger Plugin</name>
     <description>Prints XML traffic to the stdout (raw and interpreted XML)</description>
 
@@ -28,8 +28,8 @@
                 <artifactId>maven-assembly-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jspc-maven-plugin</artifactId>
+                <groupId>org.eclipse.jetty.ee8</groupId>
+                <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
             </plugin>
         </plugins>
         <resources>


### PR DESCRIPTION
This makes the plugin compatible with Openfire 5.0.0 and later (notably, a Jetty-related compatibility issue was fixed).

Fixes #34