### PR TITLE
Fix raw XML debugger logging for Netty ByteBuf traffic

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ XML Debugger Plugin Changelog
 <p><b>1.9.0</b> -- (To be determined)</p>
 <ul>
     <li>Requires Openfire 5.0.0 or later.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/36'>Issue #36</a>] - Raw XML debugger logs no traffic on Netty-based connections</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/34'>Issue #34</a>] - Compatible with Openfire 5.0</li>
 </ul>
 

--- a/src/java/org/jivesoftware/openfire/plugin/DebuggerPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/DebuggerPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software. 2023-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -139,7 +138,7 @@ public class DebuggerPlugin implements Plugin {
             @Override
             public void acceptorStopping(ConnectionAcceptor connectionAcceptor) {}
         };
-        if (!(listener.getConnectionAcceptor() instanceof NettyConnectionAcceptor)) {
+        if (listener.getConnectionAcceptor() instanceof NettyConnectionAcceptor) {
             listener.add(eventListener);
             LOGGER.info("Registering channel handler on {}", listener.getConnectionAcceptor());
             ((NettyConnectionAcceptor) listener.getConnectionAcceptor()).addChannelHandler(handler);

--- a/src/java/org/jivesoftware/openfire/plugin/RawPrintChannelHandler.java
+++ b/src/java/org/jivesoftware/openfire/plugin/RawPrintChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,14 @@
  */
 package org.jivesoftware.openfire.plugin;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.util.CharsetUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
 import java.time.ZoneOffset;
@@ -26,6 +31,8 @@ import java.time.format.DateTimeFormatter;
 
 public class RawPrintChannelHandler extends ChannelDuplexHandler
 {
+    private static final Logger Log = LoggerFactory.getLogger(RawPrintChannelHandler.class);
+
     private final String prefix;
 
     public RawPrintChannelHandler(final String prefix)
@@ -45,28 +52,46 @@ public class RawPrintChannelHandler extends ChannelDuplexHandler
     }
 
     @Override
-    public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) throws Exception
+    public void channelActive(final ChannelHandlerContext ctx) throws Exception
     {
+        final SocketAddress remoteAddress = ctx.channel() != null ? ctx.channel().remoteAddress() : null;
         DebuggerPlugin.log(messagePrefix(remoteAddress, "OPEN", ctx.name()));
 
-        super.connect(ctx, remoteAddress, localAddress, promise);
+        super.channelActive(ctx);
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception
+    public void channelInactive(final ChannelHandlerContext ctx) throws Exception
     {
         final SocketAddress remoteAddress = ctx.channel() != null ? ctx.channel().remoteAddress() : null;
         DebuggerPlugin.log(messagePrefix(remoteAddress, "CLSD", ctx.name()));
 
-        super.disconnect(ctx, promise);
+        super.channelInactive(ctx);
+    }
+
+    private static String payloadAsText(final Object msg)
+    {
+        if (msg instanceof String) {
+            return (String) msg;
+        }
+        if (msg instanceof ByteBuf) {
+            // Use the readable region without changing reader indexes.
+            return ((ByteBuf) msg).toString(CharsetUtil.UTF_8);
+        }
+        if (msg instanceof ByteBufHolder) {
+            return ((ByteBufHolder) msg).content().toString(CharsetUtil.UTF_8);
+        }
+
+        Log.debug("Unrecognized payload type '{}' - returning 'toString' as a fallback option.", msg.getClass().getName());
+        return msg.toString();
     }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        // Decode the bytebuffer and print it to the stdout
-        if (msg instanceof String && (DebuggerPlugin.logWhitespaceProperty.getValue() || !(msg.toString()).isEmpty())) {
+        final String payload = payloadAsText(msg);
+        if (payload != null && (DebuggerPlugin.logWhitespaceProperty.getValue() || !payload.isEmpty())) {
             final SocketAddress remoteAddress = ctx.channel() != null ? ctx.channel().remoteAddress() : null;
-            DebuggerPlugin.log(messagePrefix(remoteAddress, "RECV", ctx.name()) + ": " + msg);
+            DebuggerPlugin.log(messagePrefix(remoteAddress, "RECV", ctx.name()) + ": " + payload);
         }
 
         super.channelRead(ctx, msg);
@@ -75,9 +100,10 @@ public class RawPrintChannelHandler extends ChannelDuplexHandler
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception
     {
-        if (msg instanceof String && (DebuggerPlugin.logWhitespaceProperty.getValue() || !(msg.toString()).isEmpty())) {
+        final String payload = payloadAsText(msg);
+        if (payload != null && (DebuggerPlugin.logWhitespaceProperty.getValue() || !payload.isEmpty())) {
             final SocketAddress remoteAddress = ctx.channel() != null ? ctx.channel().remoteAddress() : null;
-            DebuggerPlugin.log(messagePrefix(remoteAddress, "SENT", ctx.name()) + ": " + msg);
+            DebuggerPlugin.log(messagePrefix(remoteAddress, "SENT", ctx.name()) + ": " + payload);
         }
 
         super.write(ctx, msg, promise);


### PR DESCRIPTION
Raw logging only handled String messages and used connect/disconnect lifecycle callbacks, which caused no visible output on typical server-side Netty channels.

Update RawPrintChannelHandler to:
- log OPEN/CLSD on channelActive/channelInactive
- decode and log payloads from String, ByteBuf, and ByteBufHolder (UTF-8)

This restores raw XML logging in environments where interpreted logging already worked.

fixes #36