### PR TITLE
Send XMPP fragment: supply stanza templates

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -49,6 +49,7 @@ XML Debugger Plugin Changelog
     <li>Requires Openfire 5.0.0 or later.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/36'>Issue #36</a>] - Raw XML debugger logs no traffic on Netty-based connections</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/34'>Issue #34</a>] - Compatible with Openfire 5.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/30'>Issue #30</a>] - Send XMPP fragment: provide templates</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/29'>Issue #29</a>] - Send XMPP fragment: add selection for connection</li>
 </ul>
 

--- a/src/java/org/jivesoftware/openfire/plugin/StanzaSenderServlet.java
+++ b/src/java/org/jivesoftware/openfire/plugin/StanzaSenderServlet.java
@@ -82,8 +82,25 @@ public class StanzaSenderServlet extends HttpServlet
 
         final String stanza = ParamUtils.getStringParameter(request, "stanza", "").trim();
         final String connection = ParamUtils.getStringParameter(request, "connection", DEFAULT_CONNECTION_VALUE).trim();
+        final String template = ParamUtils.getStringParameter(request, "template", "").trim();
         session.setAttribute("stanza", stanza);
         session.setAttribute("connection", connection);
+
+        if (request.getParameter("insertTemplate") != null) {
+            if (template.isEmpty()) {
+                session.setAttribute(FlashMessageTag.WARNING_MESSAGE_KEY, "Please select a template first.");
+            } else {
+                final String templatedStanza = createTemplate(template, XMPPServer.getInstance().getServerInfo().getXMPPDomain());
+                if (templatedStanza == null) {
+                    session.setAttribute(FlashMessageTag.ERROR_MESSAGE_KEY, "Unknown template selected.");
+                } else {
+                    session.setAttribute("stanza", templatedStanza);
+                    session.removeAttribute("result");
+                }
+            }
+            response.sendRedirect(request.getRequestURI());
+            return;
+        }
 
         if (stanza.isEmpty()) {
             session.setAttribute(FlashMessageTag.ERROR_MESSAGE_KEY, "Please provide input.");
@@ -181,6 +198,41 @@ public class StanzaSenderServlet extends HttpServlet
         }
 
         response.sendRedirect(request.getRequestURI());
+    }
+
+    /**
+     * Builds a frequently-used stanza template.
+     *
+     * @param templateName unique template key selected in the UI.
+     * @param xmppDomain the local XMPP domain of this server.
+     * @return stanza XML for the selected template, or {@code null} when unknown.
+     */
+    private static String createTemplate(final String templateName, final String xmppDomain) {
+        final String bareJid = "user@" + xmppDomain;
+        final String fullJid = bareJid + "/resource";
+
+        switch (templateName) {
+            case "presence-available":
+                return "<presence to='" + fullJid + "'/>";
+            case "message-chat":
+                return "<message to='" + bareJid + "' type='chat'>\n"
+                    + "    <body>Hello from Openfire admin console.</body>\n"
+                    + "</message>";
+            case "iq-ping":
+                return "<iq to='" + fullJid + "' type='get' id='ping1'>\n"
+                    + "    <ping xmlns='urn:xmpp:ping'/>\n"
+                    + "</iq>";
+            case "iq-roster-get":
+                return "<iq type='get' id='roster1'>\n"
+                    + "    <query xmlns='jabber:iq:roster'/>\n"
+                    + "</iq>";
+            case "iq-disco-info":
+                return "<iq to='" + xmppDomain + "' type='get' id='disco1'>\n"
+                    + "    <query xmlns='http://jabber.org/protocol/disco#info'/>\n"
+                    + "</iq>";
+            default:
+                return null;
+        }
     }
 
     /**

--- a/src/web/stanza-send.jsp
+++ b/src/web/stanza-send.jsp
@@ -8,12 +8,40 @@
 <head>
     <title>XML Debugger Stanza Sending Tool</title>
     <meta name="pageID" content="stanza-sender"/>
+    <style>
+        .send-pending-indicator {
+            display: none;
+            margin-left: 0.5rem;
+            align-items: center;
+            gap: 0.35rem;
+            color: #444;
+        }
+
+        .send-pending-indicator.active {
+            display: inline-flex;
+        }
+
+        .send-pending-spinner {
+            width: 0.9rem;
+            height: 0.9rem;
+            border: 2px solid #cfd5de;
+            border-top-color: #3572b0;
+            border-radius: 50%;
+            animation: send-pending-spin 0.8s linear infinite;
+        }
+
+        @keyframes send-pending-spin {
+            to {
+                transform: rotate(360deg);
+            }
+        }
+    </style>
 </head>
 <body>
 
 <admin:FlashMessage/>
 
-<form method="post">
+<form id="stanza-form" method="post">
     <input name="csrf" value="<c:out value="${csrf}"/>" type="hidden">
     <admin:contentBox title="Send XMPP stanza">
 
@@ -79,8 +107,51 @@
         </tbody>
         </table>
     </admin:contentBox>
-    <input type="submit" name="send" value="Send">
+    <input id="send-button" type="submit" name="send" value="Send">
+    <span id="send-pending-indicator" class="send-pending-indicator" aria-live="polite">
+        <span class="send-pending-spinner" aria-hidden="true"></span>
+        Sending stanza...
+    </span>
     <input type="submit" name="cancel" value="<fmt:message key="global.cancel" />">
 </form>
+<script>
+    (function () {
+        var form = document.getElementById('stanza-form');
+        if (!form) {
+            return;
+        }
+
+        var lastClickedSubmitName = null;
+        var submitButtons = form.querySelectorAll('input[type="submit"]');
+
+        submitButtons.forEach(function (button) {
+            button.addEventListener('click', function () {
+                lastClickedSubmitName = button.name || null;
+            });
+        });
+
+        form.addEventListener('submit', function (event) {
+            var submitterName = (event.submitter && event.submitter.name) ? event.submitter.name : lastClickedSubmitName;
+            if (submitterName !== 'send') {
+                return;
+            }
+
+            if (form.dataset.pendingSend === 'true') {
+                event.preventDefault();
+                return;
+            }
+
+            form.dataset.pendingSend = 'true';
+            submitButtons.forEach(function (button) {
+                button.disabled = true;
+            });
+
+            var indicator = document.getElementById('send-pending-indicator');
+            if (indicator) {
+                indicator.classList.add('active');
+            }
+        });
+    })();
+</script>
 </body>
 </html>

--- a/src/web/stanza-send.jsp
+++ b/src/web/stanza-send.jsp
@@ -36,6 +36,26 @@
         </tr>
         <tr valign="top">
             <td width="1%" nowrap>
+                <label for="template">
+                    Template
+                </label>
+            </td>
+            <td width="99%">
+                <select id="template" name="template" style="width: 100%;">
+                    <option value="">Select a frequently-used stanza template...</option>
+                    <option value="presence-available">Presence: available</option>
+                    <option value="message-chat">Message: chat</option>
+                    <option value="iq-ping">IQ: ping request (XEP-0199)</option>
+                    <option value="iq-roster-get">IQ: roster get</option>
+                    <option value="iq-disco-info">IQ: service discovery info</option>
+                </select>
+                <div style="margin-top: 0.4rem;">
+                    <input type="submit" name="insertTemplate" value="Insert template">
+                </div>
+            </td>
+        </tr>
+        <tr valign="top">
+            <td width="1%" nowrap>
                 <label for="stanza">
                     Stanza to Send
                 </label>


### PR DESCRIPTION
A couple of commonly-used XMPP stanzas can now be inserted as a template on the admin page that allows stanzas to be sent.

fixes #30 